### PR TITLE
fix: prioritize point selectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "watch": "webpack --watch --mode=development",
     "clean": "rm -rf dist",
     "type-check": "tsc --noEmit",
+    "test": "node -r ts-node/register/transpile-only tests/util.test.js",
     "deploy-chrome": "node scripts/deploy.js",
     "zip": "cd dist && zip -r ../extension.zip .",
     "sync-version": "node scripts/sync-version.js",

--- a/src/util.ts
+++ b/src/util.ts
@@ -69,7 +69,7 @@ export const parsePoints = (data: string): string => {
 
 export const findPointNode = (root: ParentNode): Element | null => {
   for (const { selector, matcher } of pointSelectors) {
-    const candidates = root.querySelectorAll(selector);
+    const candidates = Array.from(root.querySelectorAll(selector));
     for (const candidate of candidates) {
       if (!matcher || matcher(candidate)) {
         return candidate;

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,12 +1,13 @@
 /** 商品URLから取得ポイントを取得 */
 export const fetchPoints = async (url: string): Promise<string> => {
   try {
-    console.log('Fetching points for:', url);
-    
+    console.log("Fetching points for:", url);
+
     const response = await fetch(url, {
       headers: {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
-      }
+        "User-Agent":
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+      },
     });
 
     if (!response.ok) {
@@ -16,7 +17,7 @@ export const fetchPoints = async (url: string): Promise<string> => {
 
     const resData = await response.text();
     const points = parsePoints(resData);
-    console.log('Points found:', points);
+    console.log("Points found:", points);
     return points;
   } catch (error) {
     console.warn(`Failed to fetch points for ${url}:`, error);
@@ -24,25 +25,36 @@ export const fetchPoints = async (url: string): Promise<string> => {
   }
 };
 
+const pointSelectors = [
+  {
+    selector: "#addToCart #pointsInsideBuyBox_feature_div span.a-color-price",
+  },
+  {
+    selector: "#addToCart #buyBoxInner span.a-color-price:not(.offer-price)",
+    matcher: isPointCandidate,
+  },
+  {
+    selector: ".loyalty-points .a-align-bottom",
+  },
+  {
+    selector: ".ebooks-aip-points-label .a-color-price",
+  },
+  {
+    selector: "#Ebooks-desktop-KINDLE_ALC-prices-loyaltyPoints .a-color-price",
+  },
+] as Array<{
+  selector: string;
+  matcher?: (element: Element) => boolean;
+}>;
+
 /** 商品ページからポイント部分を取得
  * @param data 商品ページHTML
  */
-const parsePoints = (data: string): string => {
-  // セレクター
-  const selectors = [
-    "#addToCart #pointsInsideBuyBox_feature_div span.a-color-price",
-    "#addToCart #buyBoxInner span.a-color-price:not(.offer-price)",
-    ".loyalty-points .a-align-bottom",
-    ".ebooks-aip-points-label .a-color-price",
-    "#Ebooks-desktop-KINDLE_ALC-prices-loyaltyPoints .a-color-price"
-  ];
-
+export const parsePoints = (data: string): string => {
   try {
-    // 取得ポイント部分のDOM
-    const dom = new DOMParser()
-      .parseFromString(data, "text/html")
-      .querySelector(selectors.join(","));
-    
+    const doc = new DOMParser().parseFromString(data, "text/html");
+    const dom = findPointNode(doc);
+
     if (!dom || !dom.textContent) {
       return "";
     }
@@ -50,10 +62,40 @@ const parsePoints = (data: string): string => {
     const pointText = trimText(dom.textContent);
     return pointText ? escapeHtml(pointText) : "";
   } catch (error) {
-    console.warn('Failed to parse points:', error);
+    console.warn("Failed to parse points:", error);
     return "";
   }
 };
+
+export const findPointNode = (root: ParentNode): Element | null => {
+  for (const { selector, matcher } of pointSelectors) {
+    const candidates = root.querySelectorAll(selector);
+    for (const candidate of candidates) {
+      if (!matcher || matcher(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
+};
+
+function isPointCandidate(element: Element): boolean {
+  const texts = [
+    element.textContent,
+    element.parentElement?.textContent,
+    element.closest('[id*="point"],[class*="point"]')?.textContent,
+  ];
+
+  return texts.some((text) => looksLikePointText(text));
+}
+
+function looksLikePointText(text: string | null | undefined): boolean {
+  if (!text) return false;
+
+  const normalized = trimText(text).toLowerCase();
+  return normalized.includes("pt") || normalized.includes("ポイント");
+}
 
 /** 文字列エスケープ
  * @param unsafe 無害化する文字列

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -1,0 +1,78 @@
+const assert = require("node:assert/strict");
+const { findPointNode } = require("../src/util");
+
+const createElement = ({ textContent = "", parentTextContent, closestTextContent } = {}) => ({
+  textContent,
+  parentElement: parentTextContent
+    ? {
+        textContent: parentTextContent,
+      }
+    : null,
+  closest: () =>
+    closestTextContent
+      ? {
+          textContent: closestTextContent,
+        }
+      : null,
+});
+
+const createRoot = (selectorMap) => ({
+  querySelectorAll: (selector) => selectorMap[selector] || [],
+});
+
+const cases = [
+  {
+    name: "prefers loyalty points over earlier a-color-price nodes",
+    root: createRoot({
+      "#addToCart #pointsInsideBuyBox_feature_div span.a-color-price": [
+        createElement({ textContent: "50pt" }),
+      ],
+      "#addToCart #buyBoxInner span.a-color-price:not(.offer-price)": [
+        createElement({ textContent: "￥1,980" }),
+      ],
+    }),
+    expected: "50pt",
+  },
+  {
+    name: "ignores offer-price nodes in the buy box",
+    root: createRoot({
+      "#addToCart #buyBoxInner span.a-color-price:not(.offer-price)": [
+        createElement({ textContent: "30pt", parentTextContent: "ポイント 30pt" }),
+      ],
+    }),
+    expected: "30pt",
+  },
+  {
+    name: "does not return unrelated price labels from the broad fallback selector",
+    root: createRoot({
+      "#addToCart #buyBoxInner span.a-color-price:not(.offer-price)": [
+        createElement({ textContent: "￥1,980" }),
+        createElement({ textContent: "税込" }),
+      ],
+    }),
+    expected: null,
+  },
+  {
+    name: "supports legacy kindle point markup",
+    root: createRoot({
+      ".loyalty-points .a-align-bottom": [createElement({ textContent: "70pt" })],
+    }),
+    expected: "70pt",
+  },
+  {
+    name: "supports current kindle point markup",
+    root: createRoot({
+      "#Ebooks-desktop-KINDLE_ALC-prices-loyaltyPoints .a-color-price": [
+        createElement({ textContent: "90pt" }),
+      ],
+    }),
+    expected: "90pt",
+  },
+];
+
+for (const testCase of cases) {
+  const node = findPointNode(testCase.root);
+  assert.equal(node?.textContent ?? null, testCase.expected, testCase.name);
+}
+
+console.log(`Passed ${cases.length} util tests.`);


### PR DESCRIPTION
## Summary
- evaluate point selectors in explicit priority order instead of a single combined querySelector
- restrict the broad buy-box fallback to point-like content so unrelated price labels are ignored
- add a lightweight regression test script for the selector-priority cases from issue #21

## Testing
- corepack pnpm test
- corepack pnpm build
- corepack pnpm type-check

Closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **ポイント検出ロジックを優先度付きセレクタに変更** — Issue #21を解決するため、複数のセレクタを明示的な優先順序で評価し、ロイヤルティポイントを他の価格表示より優先するようにした。

- **findPointNode関数を新規追加** — セレクタベースのポイント抽出パイプラインを実現し、候補要素をisPointCandidate等のヒューリスティックでフィルタリングできるようにした。

- **parsePoints関数をエクスポート化** — 非エクスポートのヘルパーを公開関数として変更し、関数の再利用性を向上させた。

- **回帰テストスクリプトを追加** — tests/util.test.jsで複数のDOMパターン（通常の購入ボックス、Kindleマークアップなど）に対応したテストケースを実装し、セレクタが異なるHTML構造でも正しく動作することを検証できるようにした。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->