### PR TITLE
Support points feature div parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amazon-wishlist-pointgetter",
   "description": "Google Chrome Extension for Amazon.co.jp",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "private": true,
   "license": "MIT",
   "repository": "https://github.com/big-mon/amazon-wishlist-pointgetter",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Devola: Amazon Wishlist Point Visualization",
   "short_name": "Devola",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "__MSG_appDesc__",
   "default_locale": "ja",
   "icons": {

--- a/src/util.ts
+++ b/src/util.ts
@@ -44,17 +44,17 @@ const pointSelectors = [
   },
   {
     selector: "#points_feature_div > .a-color-price",
-    matcher: isPointCandidate,
+    matcher: isPointValueElement,
   },
   {
     selector:
       '[id*="point" i] .a-color-price, [class*="point" i] .a-color-price, [data-feature-name*="point" i] .a-color-price',
-    matcher: isPointCandidate,
+    matcher: isPointValueElement,
   },
   {
     selector:
       '[id*="point" i] span, [class*="point" i] span, [data-feature-name*="point" i] span',
-    matcher: isPointCandidate,
+    matcher: isPointValueElement,
   },
 ] as Array<{
   selector: string;
@@ -103,6 +103,10 @@ function isPointCandidate(element: Element): boolean {
   ];
 
   return texts.some((text) => looksLikePointText(text));
+}
+
+function isPointValueElement(element: Element): boolean {
+  return looksLikePointText(element.textContent);
 }
 
 function looksLikePointText(text: string | null | undefined): boolean {

--- a/src/util.ts
+++ b/src/util.ts
@@ -42,6 +42,20 @@ const pointSelectors = [
   {
     selector: "#Ebooks-desktop-KINDLE_ALC-prices-loyaltyPoints .a-color-price",
   },
+  {
+    selector: "#points_feature_div > .a-color-price",
+    matcher: isPointCandidate,
+  },
+  {
+    selector:
+      '[id*="point" i] .a-color-price, [class*="point" i] .a-color-price, [data-feature-name*="point" i] .a-color-price',
+    matcher: isPointCandidate,
+  },
+  {
+    selector:
+      '[id*="point" i] span, [class*="point" i] span, [data-feature-name*="point" i] span',
+    matcher: isPointCandidate,
+  },
 ] as Array<{
   selector: string;
   matcher?: (element: Element) => boolean;
@@ -84,7 +98,8 @@ function isPointCandidate(element: Element): boolean {
   const texts = [
     element.textContent,
     element.parentElement?.textContent,
-    element.closest('[id*="point"],[class*="point"]')?.textContent,
+    element.closest('[id*="point" i],[class*="point" i],[data-feature-name*="point" i]')
+      ?.textContent,
   ];
 
   return texts.some((text) => looksLikePointText(text));
@@ -94,7 +109,7 @@ function looksLikePointText(text: string | null | undefined): boolean {
   if (!text) return false;
 
   const normalized = trimText(text).toLowerCase();
-  return normalized.includes("pt") || normalized.includes("ポイント");
+  return /\d[\d,]*(pt|ポイント)/i.test(normalized);
 }
 
 /** 文字列エスケープ

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -99,6 +99,22 @@ const cases = [
     expected: "118pt",
   },
   {
+    name: "skips point container labels before the point value",
+    root: createRoot({
+      '[id*="point" i] span, [class*="point" i] span, [data-feature-name*="point" i] span': [
+        createElement({
+          textContent: "Amazonポイント",
+          closestTextContent: "Amazonポイント118pt",
+        }),
+        createElement({
+          textContent: "118pt",
+          closestTextContent: "Amazonポイント118pt",
+        }),
+      ],
+    }),
+    expected: "118pt",
+  },
+  {
     name: "ignores point navigation labels without point values",
     root: createRoot({
       '[id*="point" i] span, [class*="point" i] span, [data-feature-name*="point" i] span': [

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -68,6 +68,45 @@ const cases = [
     }),
     expected: "90pt",
   },
+  {
+    name: "supports logged-in all inclusive points markup",
+    root: createRoot({
+      "#points_feature_div > .a-color-price": [
+        createElement({ textContent: "62ポイント (2.5%)" }),
+      ],
+    }),
+    expected: "62ポイント (2.5%)",
+  },
+  {
+    name: "supports point feature containers outside the add to cart buy box",
+    root: createRoot({
+      '[id*="point" i] .a-color-price, [class*="point" i] .a-color-price, [data-feature-name*="point" i] .a-color-price': [
+        createElement({ textContent: "118pt" }),
+      ],
+    }),
+    expected: "118pt",
+  },
+  {
+    name: "supports the regular points feature div",
+    root: createRoot({
+      '[id*="point" i] span, [class*="point" i] span, [data-feature-name*="point" i] span': [
+        createElement({
+          textContent: "118pt",
+          closestTextContent: "ポイント:118pt",
+        }),
+      ],
+    }),
+    expected: "118pt",
+  },
+  {
+    name: "ignores point navigation labels without point values",
+    root: createRoot({
+      '[id*="point" i] span, [class*="point" i] span, [data-feature-name*="point" i] span': [
+        createElement({ textContent: "Amazonポイント" }),
+      ],
+    }),
+    expected: null,
+  },
 ];
 
 for (const testCase of cases) {


### PR DESCRIPTION
## Summary
- Add parsing support for logged-in Amazon.co.jp points markup in #points_feature_div
- Add broader point-container fallbacks while requiring numeric point text to avoid navigation false positives
- Bump extension patch version to 1.5.5

## Validation
- node -r .\\node_modules\\ts-node\\register\\transpile-only tests\\util.test.js
- node -r .\\node_modules\\ts-node\\register\\transpile-only tests\\wishlist.test.js
- .\\node_modules\\.bin\\tsc.cmd --noEmit

Note: pnpm was unavailable in this PowerShell session, so the equivalent local dependency commands were run directly.