### PR TITLE
Use Chrome Web Store v2 deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,27 +18,41 @@ jobs:
           
       - name: Check if version changed
         id: version-check
+        shell: bash
         run: |
-          # 前回のコミットとの差分をチェック
-          if git diff HEAD~1 HEAD --name-only | grep -q "package.json"; then
-            # package.jsonが変更された場合、バージョンフィールドが変更されたかチェック
-            if git diff HEAD~1 HEAD package.json | grep -q '"version"'; then
-              echo "version-changed=true" >> $GITHUB_OUTPUT
-              echo "Version changed, proceeding with deployment"
-            else
-              echo "version-changed=false" >> $GITHUB_OUTPUT
-              echo "package.json changed but version unchanged, skipping deployment"
-            fi
+          set -euo pipefail
+
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "version-changed=true" >> "$GITHUB_OUTPUT"
+            echo "Manual dispatch, proceeding with deployment"
+            exit 0
+          fi
+
+          if ! git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+            echo "version-changed=false" >> "$GITHUB_OUTPUT"
+            echo "No previous commit available, skipping deployment"
+            exit 0
+          fi
+
+          previous_version="$(git show HEAD~1:package.json | python3 -c 'import json, sys; print(json.load(sys.stdin)["version"])')"
+          current_version="$(python3 -c 'import json, pathlib; print(json.loads(pathlib.Path("package.json").read_text(encoding="utf-8"))["version"])')"
+
+          echo "Previous package.json version: ${previous_version}"
+          echo "Current package.json version: ${current_version}"
+
+          if [ "$previous_version" != "$current_version" ]; then
+            echo "version-changed=true" >> "$GITHUB_OUTPUT"
+            echo "Version changed, proceeding with deployment"
           else
-            echo "version-changed=false" >> $GITHUB_OUTPUT
-            echo "package.json not changed, skipping deployment"
+            echo "version-changed=false" >> "$GITHUB_OUTPUT"
+            echo "Version unchanged, skipping deployment"
           fi
         
       - name: Setup Node.js
         if: steps.version-check.outputs.version-changed == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: 20
           
       - name: Setup pnpm
         if: steps.version-check.outputs.version-changed == 'true'
@@ -63,12 +77,12 @@ jobs:
           
       - name: Upload to Chrome Web Store
         if: steps.version-check.outputs.version-changed == 'true'
-        uses: mnao305/chrome-extension-upload@v5.0.0
-        with:
-          file-path: extension.zip
-          extension-id: ${{ secrets.CHROME_EXTENSION_ID }}
-          client-id: ${{ secrets.CHROME_CLIENT_ID }}
-          client-secret: ${{ secrets.CHROME_CLIENT_SECRET }}
-          refresh-token: ${{ secrets.CHROME_REFRESH_TOKEN }}
-          publish: true
-          publish-target: trustedTesters
+        env:
+          CHROME_EXTENSION_ZIP_PATH: extension.zip
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CHROME_PUBLISHER_ID: ${{ secrets.CHROME_PUBLISHER_ID }}
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          CHROME_PUBLISH: "true"
+        run: node scripts/upload-chrome-web-store.js

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -10,6 +10,7 @@
 1. [Chrome Web Store Developer Dashboard](https://chrome.google.com/webstore/devconsole) にアクセス
 2. 拡張機能を登録（初回のみ手動アップロードが必要）
 3. 拡張機能IDをメモしておく（URLの `detail/` の後の文字列）
+4. Account 画面で Publisher ID を確認してメモしておく
 
 ### 2. Google Cloud Console での API設定
 
@@ -75,6 +76,7 @@ curl -X POST https://oauth2.googleapis.com/token \
 GitHub リポジトリの Settings → Secrets and variables → Actions で以下を設定：
 
 - `CHROME_EXTENSION_ID`: Chrome Web Store の拡張機能ID
+- `CHROME_PUBLISHER_ID`: Chrome Web Store の Publisher ID
 - `CHROME_CLIENT_ID`: Google Cloud Console のクライアントID
 - `CHROME_CLIENT_SECRET`: Google Cloud Console のクライアントシークレット
 - `CHROME_REFRESH_TOKEN`: 手順3で取得したリフレッシュトークン
@@ -97,6 +99,7 @@ GitHub Actions の "Deploy to Chrome Web Store" ワークフローを手動実�
 
 ```bash
 export CHROME_EXTENSION_ID="your_extension_id"
+export CHROME_PUBLISHER_ID="your_publisher_id"
 export CHROME_CLIENT_ID="your_client_id"
 export CHROME_CLIENT_SECRET="your_client_secret"
 export CHROME_REFRESH_TOKEN="your_refresh_token"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean": "rm -rf dist",
     "test": "node -r ts-node/register/transpile-only tests/util.test.js && node -r ts-node/register/transpile-only tests/wishlist.test.js",
     "type-check": "tsc --noEmit",
-    "deploy-chrome": "node scripts/deploy.js",
+    "deploy-chrome": "node scripts/upload-chrome-web-store.js",
     "zip": "cd dist && zip -r ../extension.zip .",
     "sync-version": "node scripts/sync-version.js",
     "prepare": "husky install"

--- a/scripts/upload-chrome-web-store.js
+++ b/scripts/upload-chrome-web-store.js
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const TOKEN_URL = "https://oauth2.googleapis.com/token";
+const API_ROOT = "https://chromewebstore.googleapis.com";
+const POLL_INTERVAL_MS = 5000;
+const MAX_STATUS_POLLS = 12;
+
+function readRequiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function buildItemPath(publisherId, extensionId) {
+  return `publishers/${encodeURIComponent(publisherId)}/items/${encodeURIComponent(extensionId)}`;
+}
+
+function buildApiUrl(itemPath, action, { upload = false } = {}) {
+  const baseUrl = upload
+    ? `${API_ROOT}/upload/v2/${itemPath}`
+    : `${API_ROOT}/v2/${itemPath}`;
+  const url = new URL(action ? `${baseUrl}:${action}` : baseUrl);
+  url.searchParams.set("$.xgafv", "2");
+  if (upload) {
+    url.searchParams.set("uploadType", "media");
+  }
+  return url;
+}
+
+async function parseResponse(response) {
+  const text = await response.text();
+  const contentType = response.headers.get("content-type") || "";
+
+  if (!text) {
+    return { contentType, body: null };
+  }
+
+  if (contentType.includes("application/json")) {
+    return { contentType, body: JSON.parse(text) };
+  }
+
+  try {
+    return { contentType, body: JSON.parse(text) };
+  } catch {
+    return { contentType, body: text };
+  }
+}
+
+function formatBody(body) {
+  if (body === null || body === undefined) {
+    return "(empty response)";
+  }
+
+  if (typeof body === "string") {
+    return body;
+  }
+
+  return JSON.stringify(body, null, 2);
+}
+
+function isUploadPending(uploadState) {
+  return uploadState === "IN_PROGRESS" || uploadState === "UPLOAD_IN_PROGRESS";
+}
+
+async function requestJson(label, url, options) {
+  const response = await fetch(url, options);
+  const parsed = await parseResponse(response);
+
+  if (!response.ok) {
+    const error = new Error(`${label} failed: HTTP ${response.status} ${response.statusText}`);
+    error.details = {
+      label,
+      status: response.status,
+      statusText: response.statusText,
+      contentType: parsed.contentType,
+      body: parsed.body,
+    };
+    throw error;
+  }
+
+  return parsed.body;
+}
+
+async function getAccessToken(clientId, clientSecret, refreshToken) {
+  const body = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    refresh_token: refreshToken,
+    grant_type: "refresh_token",
+  });
+
+  const response = await requestJson("OAuth token request", TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+    },
+    body,
+  });
+
+  if (!response || typeof response.access_token !== "string") {
+    throw new Error("OAuth token response did not include an access_token");
+  }
+
+  return response.access_token;
+}
+
+async function fetchStatus(itemPath, accessToken) {
+  const url = buildApiUrl(itemPath, "fetchStatus");
+
+  return requestJson("Fetch status", url, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+}
+
+async function uploadPackage(itemPath, accessToken, zipPath) {
+  const archive = fs.readFileSync(zipPath);
+  const url = buildApiUrl(itemPath, "upload", { upload: true });
+
+  return requestJson("Upload package", url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "content-type": "application/zip",
+      "content-length": String(archive.length),
+    },
+    body: archive,
+  });
+}
+
+async function publishItem(itemPath, accessToken) {
+  const url = buildApiUrl(itemPath, "publish");
+
+  return requestJson("Publish item", url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      publishType: "DEFAULT_PUBLISH",
+      skipReview: false,
+    }),
+  });
+}
+
+async function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForUploadResult(itemPath, accessToken) {
+  for (let attempt = 1; attempt <= MAX_STATUS_POLLS; attempt += 1) {
+    const status = await fetchStatus(itemPath, accessToken);
+    console.log(`Fetch status attempt ${attempt}/${MAX_STATUS_POLLS}:`);
+    console.log(formatBody(status));
+
+    const uploadState = status && status.lastAsyncUploadState;
+    if (uploadState === "SUCCEEDED" || uploadState === "FAILED" || uploadState === "NOT_FOUND") {
+      return status;
+    }
+
+    if (attempt < MAX_STATUS_POLLS) {
+      await sleep(POLL_INTERVAL_MS);
+    }
+  }
+
+  throw new Error(
+    `Upload status did not settle after ${MAX_STATUS_POLLS} attempts (${(MAX_STATUS_POLLS * POLL_INTERVAL_MS) / 1000}s)`,
+  );
+}
+
+async function logStatusSnapshot(itemPath, accessToken, heading) {
+  try {
+    const status = await fetchStatus(itemPath, accessToken);
+    console.error(`${heading}:`);
+    console.error(formatBody(status));
+  } catch (statusError) {
+    console.error(`${heading} failed: ${statusError.message}`);
+    if (statusError.details) {
+      console.error(formatBody(statusError.details));
+    }
+  }
+}
+
+async function main() {
+  const extensionId = readRequiredEnv("CHROME_EXTENSION_ID");
+  const publisherId = readRequiredEnv("CHROME_PUBLISHER_ID");
+  const clientId = readRequiredEnv("CHROME_CLIENT_ID");
+  const clientSecret = readRequiredEnv("CHROME_CLIENT_SECRET");
+  const refreshToken = readRequiredEnv("CHROME_REFRESH_TOKEN");
+  const zipPath = path.resolve(process.env.CHROME_EXTENSION_ZIP_PATH || "extension.zip");
+  const shouldPublish = (process.env.CHROME_PUBLISH || "true").toLowerCase() !== "false";
+
+  if (!fs.existsSync(zipPath)) {
+    throw new Error(`Extension archive not found: ${zipPath}`);
+  }
+
+  const itemPath = buildItemPath(publisherId, extensionId);
+  let accessToken;
+
+  console.log(`Preparing Chrome Web Store upload for item ${extensionId}`);
+  console.log(`Archive: ${zipPath}`);
+
+  try {
+    accessToken = await getAccessToken(clientId, clientSecret, refreshToken);
+    console.log("OAuth access token acquired.");
+
+    const uploadResponse = await uploadPackage(itemPath, accessToken, zipPath);
+    console.log("Upload response:");
+    console.log(formatBody(uploadResponse));
+
+    let uploadState = uploadResponse && uploadResponse.uploadState;
+    if (isUploadPending(uploadState)) {
+      const status = await waitForUploadResult(itemPath, accessToken);
+      uploadState = status && status.lastAsyncUploadState;
+    }
+
+    if (uploadState && uploadState !== "SUCCEEDED") {
+      throw new Error(`Upload did not succeed. Final upload state: ${uploadState}`);
+    }
+
+    await logStatusSnapshot(itemPath, accessToken, "Status after upload");
+
+    if (!shouldPublish) {
+      return;
+    }
+
+    const publishResponse = await publishItem(itemPath, accessToken);
+    console.log("Publish response:");
+    console.log(formatBody(publishResponse));
+    await logStatusSnapshot(itemPath, accessToken, "Status after publish");
+  } catch (error) {
+    console.error(error.message);
+    if (error.details) {
+      console.error("API error details:");
+      console.error(formatBody(error.details));
+    }
+
+    if (accessToken) {
+      await logStatusSnapshot(itemPath, accessToken, "Status snapshot after failure");
+    }
+
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Replace mnao305/chrome-extension-upload with the same Chrome Web Store v2 upload script pattern used by amazon-display-sakurachecker
- Add CHROME_PUBLISHER_ID support and richer API error logging/status snapshots
- Allow workflow_dispatch to retry deployment even when package.json version is unchanged
- Point pnpm deploy-chrome at the new upload script and document the new secret

## Validation
- node --check scripts/upload-chrome-web-store.js
- node -r .\\node_modules\\ts-node\\register\\transpile-only tests\\util.test.js
- node -r .\\node_modules\\ts-node\\register\\transpile-only tests\\wishlist.test.js
- .\\node_modules\\.bin\\tsc.cmd --noEmit
- .\\node_modules\\.bin\\webpack.cmd --mode=production

## Notes
- Add CHROME_PUBLISHER_ID to GitHub Actions secrets before running deploy.
- After merging, use workflow_dispatch to retry the 1.5.5 upload because the version is already unchanged on main.