### PR TITLE
Bump version to 1.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amazon-wishlist-pointgetter",
   "description": "Google Chrome Extension for Amazon.co.jp",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "private": true,
   "license": "MIT",
   "repository": "https://github.com/big-mon/amazon-wishlist-pointgetter",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Devola: Amazon Wishlist Point Visualization",
   "short_name": "Devola",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "__MSG_appDesc__",
   "default_locale": "ja",
   "icons": {


### PR DESCRIPTION
## Summary
- Bump package.json version to 1.5.6
- Bump Chrome extension manifest version to 1.5.6

## Validation
- Verified package.json and public/manifest.json versions both read 1.5.6